### PR TITLE
Upgrade to Scala 3

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,6 @@
 # https://scalameta.org/scalafmt/docs/configuration.html
-version = "2.7.5"
+version = 3.0.0-RC3
+runner.dialect = scala3
 preset=defaultWithAlign
 align.preset = most
 align.multiline = false

--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ lazy val root = (project in file("."))
     name := "scala-start",
     organization := "my-organization",
     version := "1.0.0",
-    scalaVersion := "2.13.5",
+    scalaVersion := "3.0.0-RC1",
     scalacOptions := scalaCompilerOptions,
-    libraryDependencies ++= akkaDependencies ++ databaseDependencies ++ testDependencies ++ loggingDependencies ++ otherDependencies
+    libraryDependencies ++= akkaDependencies ++ databaseDependencies ++ testDependencies ++ loggingDependencies
   )
   .enablePlugins(JavaAppPackaging, DockerPlugin)
 
@@ -16,78 +16,49 @@ val akkaVersion     = "2.6.13"
 val akkaHttpVersion = "10.2.4"
 
 lazy val akkaDependencies = Seq(
-  "com.typesafe.akka" %% "akka-actor"           % akkaVersion,
-  "com.typesafe.akka" %% "akka-stream"          % akkaVersion,
-  "com.typesafe.akka" %% "akka-cluster"         % akkaVersion,
-  "com.typesafe.akka" %% "akka-cluster-tools"   % akkaVersion,
-  "com.typesafe.akka" %% "akka-cluster-metrics" % akkaVersion,
-  "com.typesafe.akka" %% "akka-persistence"     % akkaVersion,
-  "com.typesafe.akka" %% "akka-http"            % akkaHttpVersion,
-  "com.typesafe.akka" %% "akka-testkit"         % akkaVersion     % Test,
-  "com.typesafe.akka" %% "akka-http-testkit"    % akkaHttpVersion % Test,
-  "de.heikoseeberger" %% "akka-http-json4s"     % "1.35.3"
+//  "com.typesafe.akka" %% "akka-actor"           % akkaVersion,
+//  "com.typesafe.akka" %% "akka-stream"          % akkaVersion,
+//  "com.typesafe.akka" %% "akka-cluster"         % akkaVersion,
+//  "com.typesafe.akka" %% "akka-cluster-tools"   % akkaVersion,
+//  "com.typesafe.akka" %% "akka-cluster-metrics" % akkaVersion,
+//  "com.typesafe.akka" %% "akka-persistence"     % akkaVersion,
+//  "com.typesafe.akka" %% "akka-http"            % akkaHttpVersion,
+//  "com.typesafe.akka" %% "akka-testkit"         % akkaVersion     % Test,
+//  "com.typesafe.akka" %% "akka-http-testkit"    % akkaHttpVersion % Test,
+//  "de.heikoseeberger" %% "akka-http-json4s"     % "1.35.3"
 )
 lazy val databaseDependencies = Seq(
-  "com.typesafe.slick" %% "slick"          % "3.3.3",
-  "com.typesafe.slick" %% "slick-hikaricp" % "3.3.3",
-  "com.typesafe.play"  %% "play-json"      % "2.9.2",
-  "org.postgresql"      % "postgresql"     % "42.2.19",
-  "com.chuusai"        %% "shapeless"      % "2.3.3",
-  "io.underscore"      %% "slickless"      % "0.3.6"
+//  "com.typesafe.slick" %% "slick"          % "3.3.3",
+//  "com.typesafe.slick" %% "slick-hikaricp" % "3.3.3",
+//  "com.typesafe.play"  %% "play-json"      % "2.9.2",
+//  "org.postgresql"      % "postgresql"     % "42.2.19",
+//  "com.chuusai"        %% "shapeless"      % "2.3.3",
+//  "io.underscore"      %% "slickless"      % "0.3.6"
 )
 
 lazy val testDependencies = Seq(
-  "org.json4s"    %% "json4s-native" % "3.6.11",
-  "org.scalatest" %% "scalatest"     % "3.2.6"   % Test,
-  "org.mockito"   %% "mockito-scala" % "1.16.32" % Test
+//  "org.json4s"    %% "json4s-native" % "3.6.11",
+//  "org.scalatest" %% "scalatest"     % "3.2.6"   % Test,
+//  "org.mockito"   %% "mockito-scala" % "1.16.32" % Test
 )
 
 lazy val loggingDependencies = Seq(
-  "com.typesafe.scala-logging" %% "scala-logging"   % "3.9.2",
-  "ch.qos.logback"              % "logback-classic" % "1.2.3",
-  "org.slf4j"                   % "slf4j-simple"    % "1.7.30"
-)
-
-lazy val otherDependencies = Seq(
-  "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
+//  "com.typesafe.scala-logging" %% "scala-logging"   % "3.9.2",
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
+  "org.slf4j"      % "slf4j-simple"    % "1.7.30"
 )
 
 lazy val scalaCompilerOptions = Seq(
-  "-target:11",
-  "-deprecation", // Emit warning and location for usages of deprecated APIs.
-  "-encoding",
-  "utf-8",                         // Specify character encoding used by source files.
-  "-explaintypes",                 // Explain type errors in more detail.
-  "-feature",                      // Emit warning and location for usages of features that should be imported explicitly.
-  "-language:existentials",        // Existential types (besides wildcard types) can be written and inferred
-  "-language:experimental.macros", // Allow macro definition (besides implementation and application)
-  "-language:higherKinds",         // Allow higher-kinded types
-  "-language:implicitConversions", // Allow definition of implicit functions called views
-  "-unchecked",                    // Enable additional warnings where generated code depends on assumptions.
-  "-Xcheckinit",                   // Wrap field accessors to throw an exception on uninitialized access.
-  "-Xfatal-warnings",              // Fail the compilation if there are any warnings.
-  "-Xlint:adapted-args",           // Warn if an argument list is modified to match the receiver.
-  "-Xlint:constant",               // Evaluation of a constant arithmetic expression results in an error.
-  "-Xlint:delayedinit-select",     // Selecting member of DelayedInit.
-  "-Xlint:doc-detached",           // A Scaladoc comment appears to be detached from its element.
-  "-Xlint:inaccessible",           // Warn about inaccessible types in method signatures.
-  "-Xlint:infer-any",              // Warn when a type argument is inferred to be `Any`.
-  "-Xlint:missing-interpolator",   // A string literal appears to be missing an interpolator id.
-  "-Xlint:nullary-unit",           // Warn when nullary methods return Unit.
-  "-Xlint:option-implicit",        // Option.apply used implicit view.
-  "-Xlint:package-object-classes", // Class or object defined in package object.
-  "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
-  "-Xlint:private-shadow",         // A private field (or class parameter) shadows a superclass field.
-  "-Xlint:stars-align",            // Pattern sequence wildcard must align with sequence component.
-  "-Xlint:type-parameter-shadow",  // A local type parameter shadows a type already in scope.
-  "-Ywarn-dead-code",              // Warn when dead code is identified.
-  "-Ywarn-extra-implicit",         // Warn when more than one implicit parameter section is defined.
-  "-Ywarn-numeric-widen",          // Warn when numerics are widened.
-  "-Ywarn-unused:implicits",       // Warn if an implicit parameter is unused.
-  "-Ywarn-unused:imports",         // Warn if an import selector is not referenced.
-  "-Ywarn-unused:locals",          // Warn if a local definition is unused.
-  "-Ywarn-unused:params",          // Warn if a value parameter is unused.
-  "-Ywarn-unused:patvars",         // Warn if a variable bound in a pattern is unused.
-  "-Ywarn-unused:privates",        // Warn if a private member is unused.
-  "-Ywarn-value-discard"           // Warn when non-Unit expression results are unused.
+  // from /usr/local/Cellar/dotty/3.0.0-RC1/bin/scalac -help
+  "-release:11",    // Compile code with classes specific to the given version of the Java platform available on the classpath and emit bytecode for this version. Choices: 8, 9, 10, 11, 12, 13, 14, 15.
+  "-deprecation",   // emit warning and location for usages of deprecated APIs
+  "-explain",       // explain errors in more detail
+  "-explain-types", // explain type errors in more detail
+  "-feature",       // emit warning and location for usages of features that should be imported explicitly
+// "-new-syntax",   // require `then` and `do` in control expressions.
+// "-no-indent"     // Require classical {...} syntax, indentation is not significant.
+  "-print-lines",     // show source code line numbers.
+  "-unchecked",       // enable additional warnings where generated code depends on assumptions
+  "-Xfatal-warnings", // fail the compilation if there are any warnings
+  "-Xmigration"       // warn about constructs whose behavior may have changed since version
 )

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val root = (project in file("."))
     name := "scala-start",
     organization := "my-organization",
     version := "1.0.0",
-    scalaVersion := "3.0.0-RC1",
+    scalaVersion := "3.0.0",
     scalacOptions := scalaCompilerOptions,
     libraryDependencies ++= akkaDependencies ++ databaseDependencies ++ testDependencies ++ loggingDependencies
   )
@@ -38,7 +38,7 @@ lazy val databaseDependencies = Seq(
 
 lazy val testDependencies = Seq(
 //  "org.json4s"    %% "json4s-native" % "3.6.11",
-  "org.scalatest" %% "scalatest"     % "3.2.6"   % Test,
+//  "org.scalatest" %% "scalatest"     % "3.2.6"   % Test,
 //  "org.mockito"   %% "mockito-scala" % "1.16.32" % Test
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,55 +1,68 @@
-lazy val root = (project in file("."))
+lazy val root = project
+  .in(file("."))
   .settings(
     name := "scala-start",
     organization := "my-organization",
     version := "1.0.0",
     scalaVersion := "3.0.0",
     scalacOptions := scalaCompilerOptions,
-    libraryDependencies ++= akkaDependencies ++ databaseDependencies ++ testDependencies ++ loggingDependencies
+    libraryDependencies ++= akkaDependencies ++
+      circeDependencies ++
+//      databaseDependencies ++
+      testDependencies ++ loggingDependencies
   )
   .enablePlugins(JavaAppPackaging, DockerPlugin)
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 ThisBuild / turbo := true
 
-val akkaVersion     = "2.6.13"
+val akkaVersion     = "2.6.14"
 val akkaHttpVersion = "10.2.4"
 
 lazy val akkaDependencies = Seq(
-//  "com.typesafe.akka" %% "akka-actor"           % akkaVersion,
-//  "com.typesafe.akka" %% "akka-stream"          % akkaVersion,
-//  "com.typesafe.akka" %% "akka-cluster"         % akkaVersion,
-//  "com.typesafe.akka" %% "akka-cluster-tools"   % akkaVersion,
-//  "com.typesafe.akka" %% "akka-cluster-metrics" % akkaVersion,
-//  "com.typesafe.akka" %% "akka-persistence"     % akkaVersion,
-//  "com.typesafe.akka" %% "akka-http"            % akkaHttpVersion,
-//  "com.typesafe.akka" %% "akka-testkit"         % akkaVersion     % Test,
-//  "com.typesafe.akka" %% "akka-http-testkit"    % akkaHttpVersion % Test,
-//  "de.heikoseeberger" %% "akka-http-json4s"     % "1.35.3"
-)
-lazy val databaseDependencies = Seq(
+  "com.typesafe.akka" %% "akka-actor"               % akkaVersion,
+  "com.typesafe.akka" %% "akka-actor-typed"         % akkaVersion,
+  "com.typesafe.akka" %% "akka-stream"              % akkaVersion,
+  "com.typesafe.akka" %% "akka-http"                % akkaHttpVersion,
+  "ch.megard"         %% "akka-http-cors"           % "1.1.1",
+  "com.typesafe.akka" %% "akka-testkit"             % akkaVersion     % Test,
+  "com.typesafe.akka" %% "akka-http-testkit"        % akkaHttpVersion % Test,
+  "com.typesafe.akka" %% "akka-actor-testkit-typed" % akkaVersion     % Test
+//  "de.heikoseeberger" %% "akka-http-json4s"  % "1.36.0"
+).map(_.cross(CrossVersion.for3Use2_13))
+
+lazy val circeDependencies = Seq(
+  "de.heikoseeberger" %% "akka-http-circe"      % "1.36.0",
+  "io.circe"          %% "circe-core"           % "0.13.0",
+  "io.circe"          %% "circe-generic"        % "0.13.0",
+  "io.circe"          %% "circe-generic-extras" % "0.13.0",
+  "io.circe"          %% "circe-parser"         % "0.13.0"
+).map(_.cross(CrossVersion.for3Use2_13))
+
+//lazy val databaseDependencies = Seq(
 //  "com.typesafe.slick" %% "slick"          % "3.3.3",
 //  "com.typesafe.slick" %% "slick-hikaricp" % "3.3.3",
 //  "com.typesafe.play"  %% "play-json"      % "2.9.2",
 //  "org.postgresql"      % "postgresql"     % "42.2.19",
 //  "com.chuusai"        %% "shapeless"      % "2.3.3",
 //  "io.underscore"      %% "slickless"      % "0.3.6"
-)
+//).map(_.cross(CrossVersion.for3Use2_13))
 
 lazy val testDependencies = Seq(
-//  "org.json4s"    %% "json4s-native" % "3.6.11",
-//  "org.scalatest" %% "scalatest"     % "3.2.6"   % Test,
-//  "org.mockito"   %% "mockito-scala" % "1.16.32" % Test
-)
+  "org.json4s"    %% "json4s-native" % "3.6.11",
+  "org.scalatest" %% "scalatest"     % "3.2.6"   % Test,
+  "org.mockito"   %% "mockito-scala" % "1.16.32" % Test
+).map(_.cross(CrossVersion.for3Use2_13))
 
 lazy val loggingDependencies = Seq(
-//  "com.typesafe.scala-logging" %% "scala-logging"   % "3.9.2",
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-  "org.slf4j"      % "slf4j-simple"    % "1.7.30"
-)
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
+//  "ch.qos.logback"              % "logback-classic" % "1.2.3",
+//  "org.slf4j"                   % "slf4j-simple"    % "1.7.30"
+).map(_.cross(CrossVersion.for3Use2_13))
 
 lazy val scalaCompilerOptions = Seq(
-  // from /usr/local/Cellar/dotty/3.0.0-RC1/bin/scalac -help
+//  "-source:3.0-migration", // reuse 2.13 language contracts
+  // from /usr/local/Cellar/dotty/3.0.0/bin/scalac -help
   "-release:11",    // Compile code with classes specific to the given version of the Java platform available on the classpath and emit bytecode for this version. Choices: 8, 9, 10, 11, 12, 13, 14, 15.
   "-deprecation",   // emit warning and location for usages of deprecated APIs
   "-explain",       // explain errors in more detail

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val databaseDependencies = Seq(
 
 lazy val testDependencies = Seq(
 //  "org.json4s"    %% "json4s-native" % "3.6.11",
-//  "org.scalatest" %% "scalatest"     % "3.2.6"   % Test,
+  "org.scalatest" %% "scalatest"     % "3.2.6"   % Test,
 //  "org.mockito"   %% "mockito-scala" % "1.16.32" % Test
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.5.0-RC1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0-RC1
+sbt.version=1.5.2

--- a/src/main/scala/Enums.scala
+++ b/src/main/scala/Enums.scala
@@ -1,0 +1,8 @@
+// https://dotty.epfl.ch/docs/reference/enums/enums.html
+enum NamedColor:
+  case Red, Green, Blue
+
+enum HexColor(val rgb: Int):
+  case Red extends HexColor(0xff0000)
+  case Green extends HexColor(0x00ff00)
+  case Blue extends HexColor(0x0000ff)

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,3 +1,2 @@
-object Main extends App {
-  println("Hello.")
-}
+object Main extends App:
+  print("Hello")

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,2 +1,8 @@
-object Main extends App:
-  print("Hello")
+package main
+
+@main def hello = println("Hello")
+
+extension (s: String) def twice = s ++ s
+
+enum Color:
+  case Red, Green, Blue

--- a/src/main/scala/NewSyntax.scala
+++ b/src/main/scala/NewSyntax.scala
@@ -1,0 +1,29 @@
+/** https://dotty.epfl.ch/docs/reference/enums/enums.html
+  */
+class NewSyntax {
+
+  var x  = 3
+  val xs = Some(2)
+  val ys = Some(3)
+
+  def f(x: Int) = x - 1
+
+  if x < 0 then "negative"
+  else if x == 0 then "zero"
+  else "positive"
+
+  if x < 0 then -x else x
+
+  while x >= 0 do x = f(x)
+
+  for x <- xs if x > 0
+  yield x * x
+
+  for
+    x <- xs
+    y <- ys
+  do println(x + y)
+
+  try println("juhu")
+  catch case ex: Throwable => println("oh no")
+}

--- a/src/test/scala/MainSpec.scala
+++ b/src/test/scala/MainSpec.scala
@@ -1,8 +1,8 @@
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.flatspec.AnyFlatSpecLike
-import org.scalatest.matchers.should.Matchers
-
-class MainSpec extends AnyFlatSpecLike with Matchers with BeforeAndAfterAll {
-
-  "This test" should "do nothing" in {}
-}
+//import org.scalatest.BeforeAndAfterAll
+//import org.scalatest.flatspec.AnyFlatSpecLike
+//import org.scalatest.matchers.should.Matchers
+//
+//class MainSpec extends AnyFlatSpecLike with Matchers with BeforeAndAfterAll {
+//
+//  "This test" should "do nothing" in {}
+//}

--- a/src/test/scala/MainSpec.scala
+++ b/src/test/scala/MainSpec.scala
@@ -1,13 +1,8 @@
-import akka.actor.ActorSystem
-import akka.testkit.TestKit
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
-class MainSpec extends TestKit(ActorSystem()) with AnyFlatSpecLike with Matchers with BeforeAndAfterAll {
-
-  override def afterAll(): Unit =
-    shutdown(system)
+class MainSpec extends AnyFlatSpecLike with Matchers with BeforeAndAfterAll {
 
   "This test" should "do nothing" in {}
 }


### PR DESCRIPTION
* Updates Scala to the current release candidate of Scala 3 and `sbt` to the supporting version.
* Updates the compiler flags to what `scalac` (RC1) offers
* Comments out dependencies that are not supported yet